### PR TITLE
chore: update docs with Infinity/Max Value warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ Using all plugins with options accommodated to an example project structure:
 })],
 ```
 
+**Be aware**, if you want to set a maximum limit with the intention of loading all file sizes, `url-loader` **limits possible solutions**, as it will not work when passed `Infinity` or `Number.MAX_VALUE`. Please use `Number.MAX_SAFE_INTEGER` if you're trying to set the highest possible limit.
+
+```js
+[withRasterImages({
+    options: {
+        limit: Infinity, // Will not work, and files will pass to fallback
+    },
+})],
+[withRasterImages({
+    options: {
+        limit: Number.MAX_SAFE_INTEGER, // Will work
+    },
+})],
+```
+
 
 ## API
 


### PR DESCRIPTION
This PR updates the documentation with a warning against using `Infinity` and `Number.MAX_VALUE` as they don't work in the current release of `url-loader`.

This issue [will make it to the next release of the loader](https://github.com/webpack-contrib/url-loader/issues/191#issuecomment-538038127), and will be eventually redundant, so this package should eventually need a PR for undoing this one.