### PR TITLE
Chore: undo docs warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,12 @@ Using all plugins with options accommodated to an example project structure:
 })],
 ```
 
-**Be aware**, if you want to set a maximum limit with the intention of loading all file sizes, `url-loader` **limits possible solutions**, as it will not work when passed `Infinity` or `Number.MAX_VALUE`. Please use `Number.MAX_SAFE_INTEGER` if you're trying to set the highest possible limit.
+If you want to set a top limit that would cover all all file sizes, you can set the limit as `Infinite`. **Keep in mind**, using data-url or inline content will **increase the size of your bundle**, and though using `Infinite` will work, it accepts all file sizes and can lead to unchecked increase in bundle size.
 
 ```js
 [withRasterImages({
-    options: {
-        limit: Infinity, // Will not work, and files will pass to fallback
-    },
-})],
-[withRasterImages({
-    options: {
-        limit: Number.MAX_SAFE_INTEGER, // Will work
+    options: {
+        limit: Infinite, // All files will pass
     },
 })],
 ```

--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ Using all plugins with options accommodated to an example project structure:
 })],
 ```
 
+**Be aware**, if you want to set a maximum limit with the intention of loading all file sizes, `url-loader` **limits possible solutions**, as it will not work when passed `Infinity` or `Number.MAX_VALUE`. Please use `Number.MAX_SAFE_INTEGER` if you're trying to set the highest possible limit.
+
+```js
+[withRasterImages({
+    options: {
+        limit: Infinity, // Will not work, and files will pass to fallback
+    },
+})],
+[withRasterImages({
+    options: {
+        limit: Number.MAX_SAFE_INTEGER, // Will work
+    },
+})],
+```
+
 
 ## API
 


### PR DESCRIPTION
url-loader has [released a new version](https://github.com/webpack-contrib/url-loader/compare/v2.1.0...v2.2.0) with a fix for the problem documented in this [PR](https://github.com/moxystudio/next-common-files/pull/4).

Added example with `Infinite` usage and a warning for awareness of bundle size.