### PR TITLE
chore: update docs with best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ Below you can find some common, general examples on how to use the plugins. Plea
 Excluding a directory:
 
 ```js
-// Exclude /images/
+// Exclude /hero/ directory
 [withRasterImages({
-    exclude: /images\/.*$/,
+    exclude: /hero\/.*$/,
+})],
+```
+
+Excluding a file by suffix:
+
+```js
+// Exclude files with '.data-url' suffix
+[withRasterImages({
+    exclude: /\.data-url\./,
 })],
 ```
 
@@ -93,14 +102,14 @@ Setting the `url-loader` limit:
 Using limit and exclude/include to delineate between data URL items and standard items:
 
 ```js
-// Exclude data-url directory
+// Exclude files with '.data-url' suffix
 [withRasterImages({
-     exclude: /data-url\/.*$/,
+     exclude: /\.data-url\./,
 })],
 
-// Set a higher limit for appropriate directory
+// Set a higher limit for files with '.data-url' suffix
 [withRasterImages({
-    include: /data-url\/.*$/,
+    include: /\.data-url\./,
     options: {
         limit: 300000,
     },
@@ -120,20 +129,21 @@ Using all plugins with options accommodated to an example project structure:
     },
 })],
 [withSVG({
-    exclude: [/images\/.*.svg$/, /favicons\/.*.svg/],
-    inline: true,
+    exclude: /\.inline\./,
 })],
 [withSVG({
-    include: /images\/.*.svg$/,
+    include: /\.inline\./,
+    inline: true,
 })],
 ```
 
-If you want to set a top limit thagitt would cover all all file sizes, you can set the limit as `Infinite`. **Keep in mind**, using data-url or inline content will **increase the size of your bundle**, and though using `Infinite` will work, it accepts all file sizes and can lead to unchecked increase in bundle size.
+If you want to set a top limit that would cover all file sizes, you can set the limit as `Infinity`. **Keep in mind**, using data-url or inline content will **increase the size of your bundle**, and defaulting to `Infinity` can lead to an unchecked increase in bundle size.
+
 
 ```js
 [withRasterImages({
     options: {
-        limit: Infinite, // All files will pass
+        limit: Infinity, // All files will pass
     },
 })],
 ```
@@ -176,7 +186,7 @@ The available options also change in accordance with the `inline` value. With th
 
 // If sent true, 'use' value will override default loaders entirely
 [withSVG({
-    exclude: /inline\/.*.svg$/,    // Will be safely passed to rule
+    include: /\.inline\./,        // Will be safely passed to rule
     inline: true,
     use: [{
         loader: 'url-loader',     // Only 'url-loader' will be used
@@ -187,15 +197,15 @@ The available options also change in accordance with the `inline` value. With th
 The following example shows how you can use the inline option in your project:
 
 ```js
-// Inline SVGs are stored in /inline/
+// Inline SVGs have a '.inline' suffix
 [withSVG({
-    include: /inline\/.*.svg$/,
+    include: /\.inline\./,
     inline: true,
 })],
 
-// Exclude /inline/
+// Exclude files with '.inline' suffix
 [withSVG({
-    exclude: /inline\/.*.svg$/,
+    exclude: /\.inline\./,
 })],
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ withSVG({
 The following example shows how you can use the inline option in your project:
 
 ```js
-// Inline SVGs have a '.inline' suffix
+// Include SVGs with '.inline' suffix
 withSVG({
     include: /\.inline\./,
     inline: true,

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ const { withRasterImages, withPlayback, withFonts, withSVG } = require('@moxy/ne
 const withPlugins = require('next-compose-plugins');
 
 module.exports = withPlugins([
-        [withRasterImages()],
-        [withPlayback()],
-        [withFonts()],
-        [withSVG()],
+        withRasterImages(),
+        withPlayback(),
+        withFonts(),
+        withSVG(),
     ]);
 ```
 
@@ -74,78 +74,78 @@ Excluding a directory:
 
 ```js
 // Exclude /images/ directory
-[withRasterImages({
+withRasterImages({
     exclude: /images\/.*$/,
-})],
+}),
 ```
 
 Excluding a file by suffix:
 
 ```js
 // Exclude files with '.data-url' suffix
-[withRasterImages({
+withRasterImages({
     exclude: /\.data-url\./,
-})],
+}),
 ```
 
 Setting the `url-loader` limit:
 
 ```js
 // Set higher limit
-[withRasterImages({
+withRasterImages({
     options: {
         limit: 300000,
     },
-})],
+}),
 ```
 
 Using limit and exclude/include to delineate between data URL items and standard items:
 
 ```js
 // Exclude files with '.data-url' suffix
-[withRasterImages({
+withRasterImages({
      exclude: /\.data-url\./,
-})],
+}),
 
 // Set a higher limit for files with '.data-url' suffix
-[withRasterImages({
+withRasterImages({
     include: /\.data-url\./,
     options: {
         limit: 300000,
     },
-})],
+}),
 ```
 
 Using all plugins with options accommodated to an example project structure:
 
 ```js
-[withRasterImages({
+withRasterImages({
     exclude: /favicons\/.*$/,
-})],
-[withPlayback()],
-[withFonts({
+}),
+withPlayback(),
+withFonts({
     options: {
         limit: 50000,
     },
-})],
-[withSVG({
+}),
+withSVG({
     exclude: /\.inline\./,
-})],
-[withSVG({
+}),
+withSVG({
     include: /\.inline\./,
     inline: true,
-})],
+}),
 ```
 
 If you want to set a top limit that would cover all file sizes, you can set the limit as `Infinity`. **Keep in mind**, using data-url or inline content will **increase the size of your bundle**, and defaulting to `Infinity` can lead to an unchecked increase in bundle size.
 
 
 ```js
-[withRasterImages({
+withRasterImages({
     options: {
         limit: Infinity, // All files will pass
     },
-})],
+}),
 ```
 
 
@@ -178,35 +178,35 @@ The available options also change in accordance with the `inline` value. With th
 
 ```js
 // If false or not sent, options can be sent like other plugins
-[withSVG({
+withSVG({
     options: {
         limit: 20000,    // will be safely passed to url-loader
     },
-})],
+}),
 
 // If sent true, 'use' value will override default loaders entirely
-[withSVG({
+withSVG({
     include: /\.inline\./,        // Will be safely passed to rule
     inline: true,
     use: [{
         loader: 'url-loader',     // Only 'url-loader' will be used
     }],
-})],
+}),
 ```
 
 The following example shows how you can use the inline option in your project:
 
 ```js
 // Inline SVGs have a '.inline' suffix
-[withSVG({
+withSVG({
     include: /\.inline\./,
     inline: true,
-})],
+}),
 
 // Exclude SVGs with '.inline' suffix
-[withSVG({
+withSVG({
     exclude: /\.inline\./,
-})],
+}),
 ```
 
 **Keep in mind**, when you opt in for the inline output, the CSS classes in your SVG **will be uniquified**, and you must be careful when selecting them. For example, using an attribute selector, as shown in the following snippet:

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Below you can find some common, general examples on how to use the plugins. Plea
 Excluding a directory:
 
 ```js
-// Exclude /hero/ directory
+// Exclude /images/ directory
 [withRasterImages({
-    exclude: /hero\/.*$/,
+    exclude: /images\/.*$/,
 })],
 ```
 
@@ -203,7 +203,7 @@ The following example shows how you can use the inline option in your project:
     inline: true,
 })],
 
-// Exclude files with '.inline' suffix
+// Exclude SVGs with '.inline' suffix
 [withSVG({
     exclude: /\.inline\./,
 })],


### PR DESCRIPTION
For [next-with-moxy](https://github.com/moxystudio/next-with-moxy), it was decided that a filename suffix would decide whether a file would load inline, data-url, or url ([see commit](https://github.com/moxystudio/next-with-moxy/pull/3/commits/6473122a329ff34c3142884cb0fd4ded8490f27b)), but that practice wasn't documented in this package at all. This means the documentation does not exemplify how this package is primarily used, or reflect company practices. 

This PR adds examples using filename suffixes, to stay in accordance with company practices and next-with-moxy