### PR TITLE
fix: fix options next to use

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -18,7 +18,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => ({
         webpack(config, options) {
             const { dev, isServer } = options;
             const { assetPrefix = '' } = nextConfig;
-            const { inline = false, ...userOptions } = pluginOptions;
+            const { inline = false, options: loaderOptions, ...userOptions } = pluginOptions;
 
             if (inline) {
                 config.module.rules.push({
@@ -49,7 +49,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => ({
                                 publicPath: `${assetPrefix}_next/static/chunks/media`,
                                 outputPath: 'static/chunks/media',
                                 emitFile: !isServer,
-                                ...userOptions.options,
+                                ...loaderOptions,
                             },
                         },
                         svgoLoader,


### PR DESCRIPTION
In webpack loaders, you cannot have an options/query key at the same level as the use key ([src](https://github.com/webpack/webpack/issues/3645#issuecomment-269765612)).

This PR guarantees that this never happens.