### PR TITLE
feat(3d): add glTF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ withSVG({
 
 ### 3d
 
-This plugin is meant to handle **3d** files, and tests the file types `.obj`, `.mtl`, `.fnt`, and`.glb`.
+This plugin is meant to handle **3d** files, and tests the file types `.obj`, `.mtl`, `.fnt`, `.gltf` and `.glb`.
 
 ## Tests
 

--- a/lib/3d.js
+++ b/lib/3d.js
@@ -7,7 +7,7 @@ module.exports = (userOptions = {}) => (nextConfig = {}) => ({
         const { dev, isServer } = options;
 
         config.module.rules.push({
-            test: /\.(obj|mtl|fnt|glb)$/,
+            test: /\.(obj|mtl|fnt|gltf|glb)$/,
             loader: require.resolve('url-loader'),
             ...userOptions,
             options: {

--- a/lib/__snapshots__/3d.test.js.snap
+++ b/lib/__snapshots__/3d.test.js.snap
@@ -10,6 +10,6 @@ Object {
     "outputPath": "static/chunks/media",
     "publicPath": "/_next/static/chunks/media",
   },
-  "test": /\\\\\\.\\(obj\\|mtl\\|fnt\\|glb\\)\\$/,
+  "test": /\\\\\\.\\(obj\\|mtl\\|fnt\\|gltf\\|glb\\)\\$/,
 }
 `;


### PR DESCRIPTION
Adds support for glTF filetypes.

This package already supports `.glb` files, which are a binary form of `.gltf`, but there are sufficient already gains from using `.gltf`, especially when also using Draco compression, to justify having it as an option against `.obj` files.